### PR TITLE
feat: add maximum run speed to character movement configuration

### DIFF
--- a/client/src/constants/movement.rs
+++ b/client/src/constants/movement.rs
@@ -11,6 +11,7 @@ impl CharacterMovementConfig {
     pub const MOVEMENT_ACCELERATION: f32 = 30.0;
     pub const MOVEMENT_DECELERATION: f32 = 40.0;
     pub const MAX_SPEED: f32 = 5.0;
+    pub const MAX_RUN_SPEED: f32 = 13.5; // Maximum speed when running/sprinting
     pub const ROTATION_SPEED: f32 = 5.0;
 
     // Air and ground friction constants

--- a/client/src/systems/character_controller.rs
+++ b/client/src/systems/character_controller.rs
@@ -195,7 +195,11 @@ fn movement(
                     let movement_direction = (forward * -direction.y) + (right * direction.x);
 
                     // Calculate target velocity
-                    let target_speed = CharacterMovementConfig::MAX_SPEED * direction.length();
+                    let target_speed = if animation_state.forward_hold_time >= 3.0 {
+                        CharacterMovementConfig::MAX_RUN_SPEED * direction.length()
+                    } else {
+                        CharacterMovementConfig::MAX_SPEED * direction.length()
+                    };
                     let current_speed = Vec2::new(linear_velocity.x, linear_velocity.z).length();
 
                     // Smooth acceleration/deceleration


### PR DESCRIPTION
- Introduced a new constant `MAX_RUN_SPEED` to define the maximum speed during running or sprinting.
- Updated the character movement logic to utilize `MAX_RUN_SPEED` when the forward hold time exceeds 3 seconds, enhancing movement dynamics and responsiveness.